### PR TITLE
feat: fail when global telemetry limits cannot be enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This tool makes those problems visible before release.
 - Fails if quality drops below your threshold
 - Optionally compares against a baseline report and blocks regressions
 - Supports per-case latency/cost limits to catch outliers hidden by averages
+- Enforces telemetry presence when global average latency/cost limits are configured
 - Outputs both JSON (for machines) and Markdown (for humans)
 
 ## Install
@@ -66,6 +67,8 @@ cases:
 ```
 
 `max_latency_ms` and `max_cost_usd` are optional per-case guardrails. If set, that case fails when telemetry is missing or exceeds the limit.
+
+When `max_avg_latency_ms` or `max_avg_cost_usd` is configured globally, the gate also fails if the corresponding telemetry is missing across the run.
 
 ## Repo layout
 

--- a/src/agent_release_gate/evaluator.py
+++ b/src/agent_release_gate/evaluator.py
@@ -138,17 +138,29 @@ def evaluate(
             f"Pass rate {pass_rate:.2%} is below minimum {spec.minimum_pass_rate:.2%}"
         )
 
-    if spec.max_avg_latency_ms is not None and avg_latency is not None and avg_latency > spec.max_avg_latency_ms:
-        gate_passed = False
-        reasons.append(
-            f"Average latency {avg_latency:.1f}ms exceeds limit {spec.max_avg_latency_ms}ms"
-        )
+    if spec.max_avg_latency_ms is not None:
+        if avg_latency is None:
+            gate_passed = False
+            reasons.append(
+                "Average latency limit is configured, but no latency telemetry was provided"
+            )
+        elif avg_latency > spec.max_avg_latency_ms:
+            gate_passed = False
+            reasons.append(
+                f"Average latency {avg_latency:.1f}ms exceeds limit {spec.max_avg_latency_ms}ms"
+            )
 
-    if spec.max_avg_cost_usd is not None and avg_cost is not None and avg_cost > spec.max_avg_cost_usd:
-        gate_passed = False
-        reasons.append(
-            f"Average cost ${avg_cost:.4f} exceeds limit ${spec.max_avg_cost_usd:.4f}"
-        )
+    if spec.max_avg_cost_usd is not None:
+        if avg_cost is None:
+            gate_passed = False
+            reasons.append(
+                "Average cost limit is configured, but no cost telemetry was provided"
+            )
+        elif avg_cost > spec.max_avg_cost_usd:
+            gate_passed = False
+            reasons.append(
+                f"Average cost ${avg_cost:.4f} exceeds limit ${spec.max_avg_cost_usd:.4f}"
+            )
 
     if baseline_path:
         baseline = load_json(baseline_path)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -147,3 +147,61 @@ cases:
     assert report.cases[0].passed is False
     assert "Missing latency_ms for case with max_latency_ms set" in report.cases[0].notes
     assert "Missing cost_usd for case with max_cost_usd set" in report.cases[0].notes
+
+
+def test_global_latency_limit_requires_telemetry_when_configured(tmp_path: Path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        """
+global:
+  minimum_pass_rate: 1.0
+  max_avg_latency_ms: 1000
+cases:
+  - id: case_1
+    expected_all: ["refund"]
+    min_score: 0.7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    results = tmp_path / "results.json"
+    results.write_text(
+        '{"cases":[{"id":"case_1","response":"refund confirmed"}]}',
+        encoding="utf-8",
+    )
+
+    report = evaluate(spec, results)
+    assert report.summary.gate_passed is False
+    assert any(
+        "Average latency limit is configured, but no latency telemetry was provided" in r
+        for r in report.summary.gate_reasons
+    )
+
+
+def test_global_cost_limit_requires_telemetry_when_configured(tmp_path: Path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        """
+global:
+  minimum_pass_rate: 1.0
+  max_avg_cost_usd: 0.01
+cases:
+  - id: case_1
+    expected_all: ["refund"]
+    min_score: 0.7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    results = tmp_path / "results.json"
+    results.write_text(
+        '{"cases":[{"id":"case_1","response":"refund confirmed"}]}',
+        encoding="utf-8",
+    )
+
+    report = evaluate(spec, results)
+    assert report.summary.gate_passed is False
+    assert any(
+        "Average cost limit is configured, but no cost telemetry was provided" in r
+        for r in report.summary.gate_reasons
+    )


### PR DESCRIPTION
## Summary
This PR tightens release safety: if global average telemetry limits are configured (`max_avg_latency_ms` / `max_avg_cost_usd`) but telemetry is missing, the gate now fails instead of silently passing.

## Why
Teams are using agent quality gates to stop regressions in CI, but missing telemetry created a blind spot where configured global limits were never enforced.

## What changed
- Updated evaluator logic to fail when:
  - `max_avg_latency_ms` is set and no latency telemetry is present
  - `max_avg_cost_usd` is set and no cost telemetry is present
- Added focused tests for both new fail-fast paths
- Updated README to document telemetry-required behavior for global limits

## Validation evidence
All checks run locally and passed.

1) **Repo-level/full test suite**
- Command: `python3 -m pytest`
- Result: ✅ pass (`7 passed in 0.04s`)

2) **Targeted tests for changed module**
- Command: `python3 -m pytest tests/test_evaluator.py -k 'global_latency_limit_requires_telemetry_when_configured or global_cost_limit_requires_telemetry_when_configured'`
- Result: ✅ pass (`2 passed, 4 deselected in 0.01s`)

3) **Lint/type/build checks**
- Command: `python3 -m ruff check src tests`
- Result: ✅ pass (`All checks passed!`)
- Command: `python3 -m build`
- Result: ✅ pass (`Successfully built ... .tar.gz and ... .whl`)

4) **Smoke/integration check**
- Command: `PYTHONPATH=src python3 -m agent_release_gate.cli evaluate --spec examples/spec.yaml --results examples/results.json`
- Result: ✅ pass (`gate_passed=True`, `pass_rate=1.0`)

## Risk
Low. Change is scoped to gate decision logic for already-configured global limits.
