### PR TITLE
feat: add baseline latency/cost regression caps to release gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This tool makes those problems visible before release.
 - Calculates pass rate, average latency, and average cost
 - Fails if quality drops below your threshold
 - Optionally compares against a baseline report and blocks regressions
+- Optionally enforces baseline latency/cost drift caps so slower or pricier runs fail fast
 - Supports per-case latency/cost limits to catch outliers hidden by averages
 - Enforces telemetry presence when global average latency/cost limits are configured
 - Outputs both JSON (for machines) and Markdown (for humans)
@@ -55,6 +56,8 @@ global:
   allowed_regression: 0.02
   max_avg_latency_ms: 1500
   max_avg_cost_usd: 0.03
+  max_avg_latency_regression_pct: 0.15
+  max_avg_cost_regression_pct: 0.10
 
 cases:
   - id: refund_status
@@ -69,6 +72,8 @@ cases:
 `max_latency_ms` and `max_cost_usd` are optional per-case guardrails. If set, that case fails when telemetry is missing or exceeds the limit.
 
 When `max_avg_latency_ms` or `max_avg_cost_usd` is configured globally, the gate also fails if the corresponding telemetry is missing across the run.
+
+When `--baseline` is provided, you can also set `max_avg_latency_regression_pct` and/or `max_avg_cost_regression_pct` to fail if average latency or cost regresses beyond the allowed percentage increase vs baseline.
 
 ## Repo layout
 

--- a/examples/spec.yaml
+++ b/examples/spec.yaml
@@ -3,6 +3,8 @@ global:
   allowed_regression: 0.03
   max_avg_latency_ms: 1500
   max_avg_cost_usd: 0.03
+  max_avg_latency_regression_pct: 0.15
+  max_avg_cost_regression_pct: 0.1
 
 cases:
   - id: refund_status

--- a/src/agent_release_gate/evaluator.py
+++ b/src/agent_release_gate/evaluator.py
@@ -164,12 +164,61 @@ def evaluate(
 
     if baseline_path:
         baseline = load_json(baseline_path)
-        baseline_pass_rate = float(baseline.get("summary", {}).get("pass_rate", 0.0))
+        baseline_summary = baseline.get("summary", {}) or {}
+        baseline_pass_rate = float(baseline_summary.get("pass_rate", 0.0))
         if pass_rate < (baseline_pass_rate - spec.allowed_regression):
             gate_passed = False
             reasons.append(
                 f"Regression detected: current {pass_rate:.2%}, baseline {baseline_pass_rate:.2%}, allowed drop {spec.allowed_regression:.2%}"
             )
+
+        if spec.max_avg_latency_regression_pct is not None:
+            baseline_latency = baseline_summary.get("avg_latency_ms")
+            if baseline_latency is None or avg_latency is None:
+                gate_passed = False
+                reasons.append(
+                    "Latency regression limit is configured, but baseline or current average latency telemetry is missing"
+                )
+            else:
+                baseline_latency_f = float(baseline_latency)
+                if baseline_latency_f <= 0:
+                    gate_passed = False
+                    reasons.append(
+                        "Latency regression limit is configured, but baseline avg_latency_ms must be > 0"
+                    )
+                else:
+                    latency_increase_pct = (avg_latency - baseline_latency_f) / baseline_latency_f
+                    if latency_increase_pct > spec.max_avg_latency_regression_pct:
+                        gate_passed = False
+                        reasons.append(
+                            "Latency regression detected: "
+                            f"current {avg_latency:.1f}ms vs baseline {baseline_latency_f:.1f}ms "
+                            f"({latency_increase_pct:.2%} increase, allowed {spec.max_avg_latency_regression_pct:.2%})"
+                        )
+
+        if spec.max_avg_cost_regression_pct is not None:
+            baseline_cost = baseline_summary.get("avg_cost_usd")
+            if baseline_cost is None or avg_cost is None:
+                gate_passed = False
+                reasons.append(
+                    "Cost regression limit is configured, but baseline or current average cost telemetry is missing"
+                )
+            else:
+                baseline_cost_f = float(baseline_cost)
+                if baseline_cost_f <= 0:
+                    gate_passed = False
+                    reasons.append(
+                        "Cost regression limit is configured, but baseline avg_cost_usd must be > 0"
+                    )
+                else:
+                    cost_increase_pct = (avg_cost - baseline_cost_f) / baseline_cost_f
+                    if cost_increase_pct > spec.max_avg_cost_regression_pct:
+                        gate_passed = False
+                        reasons.append(
+                            "Cost regression detected: "
+                            f"current ${avg_cost:.6f} vs baseline ${baseline_cost_f:.6f} "
+                            f"({cost_increase_pct:.2%} increase, allowed {spec.max_avg_cost_regression_pct:.2%})"
+                        )
 
     if gate_passed:
         reasons.append("Gate passed")

--- a/src/agent_release_gate/models.py
+++ b/src/agent_release_gate/models.py
@@ -21,6 +21,8 @@ class GateSpec:
     allowed_regression: float = 0.02
     max_avg_latency_ms: Optional[int] = None
     max_avg_cost_usd: Optional[float] = None
+    max_avg_latency_regression_pct: Optional[float] = None
+    max_avg_cost_regression_pct: Optional[float] = None
     cases: list[GateCase] = field(default_factory=list)
 
 
@@ -96,6 +98,16 @@ def parse_spec(data: dict[str, Any]) -> GateSpec:
         max_avg_cost_usd=(
             float(global_cfg["max_avg_cost_usd"])
             if global_cfg.get("max_avg_cost_usd") is not None
+            else None
+        ),
+        max_avg_latency_regression_pct=(
+            float(global_cfg["max_avg_latency_regression_pct"])
+            if global_cfg.get("max_avg_latency_regression_pct") is not None
+            else None
+        ),
+        max_avg_cost_regression_pct=(
+            float(global_cfg["max_avg_cost_regression_pct"])
+            if global_cfg.get("max_avg_cost_regression_pct") is not None
             else None
         ),
         cases=cases,

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -205,3 +205,101 @@ cases:
         "Average cost limit is configured, but no cost telemetry was provided" in r
         for r in report.summary.gate_reasons
     )
+
+
+def test_baseline_latency_regression_limit_blocks_slowdown(tmp_path: Path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        """
+global:
+  minimum_pass_rate: 1.0
+  max_avg_latency_regression_pct: 0.10
+cases:
+  - id: case_1
+    expected_all: ["refund"]
+    min_score: 0.7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    results = tmp_path / "results.json"
+    results.write_text(
+        '{"cases":[{"id":"case_1","response":"refund confirmed","latency_ms":1300}]}',
+        encoding="utf-8",
+    )
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        '{"summary":{"pass_rate":1.0,"avg_latency_ms":1000},"cases":[]}',
+        encoding="utf-8",
+    )
+
+    report = evaluate(spec, results, baseline)
+    assert report.summary.gate_passed is False
+    assert any("Latency regression detected" in r for r in report.summary.gate_reasons)
+
+
+def test_baseline_cost_regression_limit_blocks_spend_drift(tmp_path: Path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        """
+global:
+  minimum_pass_rate: 1.0
+  max_avg_cost_regression_pct: 0.20
+cases:
+  - id: case_1
+    expected_all: ["refund"]
+    min_score: 0.7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    results = tmp_path / "results.json"
+    results.write_text(
+        '{"cases":[{"id":"case_1","response":"refund confirmed","cost_usd":0.018}]}',
+        encoding="utf-8",
+    )
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        '{"summary":{"pass_rate":1.0,"avg_cost_usd":0.01},"cases":[]}',
+        encoding="utf-8",
+    )
+
+    report = evaluate(spec, results, baseline)
+    assert report.summary.gate_passed is False
+    assert any("Cost regression detected" in r for r in report.summary.gate_reasons)
+
+
+def test_baseline_regression_limits_require_current_and_baseline_telemetry(tmp_path: Path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        """
+global:
+  minimum_pass_rate: 1.0
+  max_avg_latency_regression_pct: 0.15
+  max_avg_cost_regression_pct: 0.15
+cases:
+  - id: case_1
+    expected_all: ["refund"]
+    min_score: 0.7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    results = tmp_path / "results.json"
+    results.write_text(
+        '{"cases":[{"id":"case_1","response":"refund confirmed"}]}',
+        encoding="utf-8",
+    )
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        '{"summary":{"pass_rate":1.0},"cases":[]}',
+        encoding="utf-8",
+    )
+
+    report = evaluate(spec, results, baseline)
+    assert report.summary.gate_passed is False
+    assert any("Latency regression limit is configured" in r for r in report.summary.gate_reasons)
+    assert any("Cost regression limit is configured" in r for r in report.summary.gate_reasons)


### PR DESCRIPTION
## Summary
Adds optional baseline drift guardrails so releases fail when average latency or cost regresses too far versus baseline, not just pass rate.

## Why
Agent teams keep reporting quality can look stable while latency/cost quietly degrade. This closes that gap and keeps release gates aligned with production economics.

## What changed
- Added `max_avg_latency_regression_pct` and `max_avg_cost_regression_pct` global spec options
- Enforced failures when current run exceeds configured baseline drift thresholds
- Added explicit failure reasons for missing/invalid baseline telemetry
- Added evaluator tests for latency drift, cost drift, and telemetry-missing paths
- Updated README + example spec with new config options

## Validation evidence
- `python3 -m pytest` → **10 passed**
- `python3 -m pytest tests/test_evaluator.py -k baseline` → **3 passed, 6 deselected**
- `python3 -m ruff check .` → **All checks passed**
- `python3 -m mypy src` → **Success: no issues found in 4 source files**
- `python3 -m build` → **Built sdist + wheel successfully**
- Smoke/integration check (expected fail path):
  - Command: `PYTHONPATH=src python3 -m agent_release_gate.cli evaluate --spec <tmp>/spec.yaml --results <tmp>/results.json --baseline <tmp>/baseline.json`
  - Result: **exit_code=1**, `gate_passed=false`, reason includes `Latency regression detected: current 1300.0ms vs baseline 1000.0ms (30.00% increase, allowed 10.00%)`

## Docs tone check
- `node src/cli.js score -f /Users/bwise/.openclaw/workspace/projects/agent-release-gate/README.md` (run from `projects/humanizer`) → **🟢 0/100**
